### PR TITLE
making do-fx private

### DIFF
--- a/src/greenpowermonitor/reffectory.cljc
+++ b/src/greenpowermonitor/reffectory.cljc
@@ -31,7 +31,7 @@
     (when data
       ((get-handler :fxs effect-id) data))))
 
-(def do-fx
+(def ^:private do-fx
   (interceptor {:id :do-fx
                 :after (fn [{:keys [effects]}]
                          (handle-effects effects))}))


### PR DESCRIPTION
It makes `do-fx` var private.